### PR TITLE
fix :not done tab to use modal reject-radiology-order-dialog

### DIFF
--- a/src/radiology-tabs/test-ordered/tests-ordered.component.tsx
+++ b/src/radiology-tabs/test-ordered/tests-ordered.component.tsx
@@ -37,7 +37,7 @@ const RejectOrderMenuItem: React.FC<RejectOrderOverflowMenuItemProps> = ({
   order,
 }) => {
   const handleRejectOrderModel = useCallback(() => {
-    const dispose = showModal("reject-order-dialog", {
+    const dispose = showModal("reject-radiology-order-dialog", {
       closeModal: () => dispose(),
       order,
     });


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR populates the not done tab on the radiology page.The fix replaces modal reject-order-dialog(fetches referred out patients) with reject-radiology-order-dialog(fetches rejected orders)

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->
![Peek 2024-04-16 17-34](https://github.com/palladiumkenya/esm-radiology-app/assets/85983194/dd4a8eb2-d169-44dc-8e54-0f4ef14391d7)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
